### PR TITLE
모달창 모바일에서 비활성화 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^19.2.0",
         "react-masonry-css": "^1.0.16",
         "react-modal": "^3.16.3",
+        "react-responsive": "^10.0.1",
         "react-router-dom": "^7.9.6"
       },
       "devDependencies": {
@@ -2178,6 +2179,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+      "license": "BSD"
+    },
     "node_modules/css-tree": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
@@ -2959,6 +2966,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -3562,6 +3575,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/matchmediaquery": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.4.2.tgz",
+      "integrity": "sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -4115,6 +4137,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-responsive": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-10.0.1.tgz",
+      "integrity": "sha512-OM5/cRvbtUWEX8le8RCT8scA8y2OPtb0Q/IViEyCEM5FBN8lRrkUOZnu87I88A6njxDldvxG+rLBxWiA7/UM9g==",
+      "license": "MIT",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.4.2",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "7.9.6",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.6.tgz",
@@ -4302,6 +4342,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/shallow-equal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^19.2.0",
     "react-masonry-css": "^1.0.16",
     "react-modal": "^3.16.3",
+    "react-responsive": "^10.0.1",
     "react-router-dom": "^7.9.6"
   },
   "devDependencies": {

--- a/public/imageData.json
+++ b/public/imageData.json
@@ -574,14 +574,5 @@
       "group": "배너",
       "urlConverted": "banner/baseball_banner_img_4_converted.webp"
     }
-  ],
-  "eventImg": [
-    {
-      "id": 1,
-      "title": "Instagram Link",
-      "url": "eventImg/instagramLink.png",
-      "description": "작가 인스타그램 QR 링크",
-      "group": "eventImg"
-    }
   ]
 }

--- a/src/modules/gallery/galleryContents.tsx
+++ b/src/modules/gallery/galleryContents.tsx
@@ -1,10 +1,15 @@
 import React, { useState } from "react";
 import Masonry from "react-masonry-css"; // react-masonry-css에서 임포트
 import Modal from "react-modal";
+import { useMediaQuery } from "react-responsive"; // 모바일. PC 판독 플러그인
 import { AllImageData, ImageItems } from "../../types/imageData";
+import { useImageData } from "../../context/ImageDataContext";
 
 Modal.setAppElement("#root"); // 또는 앱의 최상위 DOM ID
-export default function GalleryContents({ filteredImages }: AllImageData) {
+export default function GalleryContents() {
+  const allimageData = useImageData();
+  const isMobile = useMediaQuery({ maxWidth: 767 }); //모바일 조건 적용
+
   // 반응형 컬럼 개수 설정
   const breakpointColumnsObj = {
     default: 4, // 기본값 (가장 큰 화면)
@@ -14,29 +19,33 @@ export default function GalleryContents({ filteredImages }: AllImageData) {
     640: 1, // 640px 이하
   };
 
-  console.log(filteredImages);
+  const withOutBannerImgs: ImageItems[] = allimageData
+    ? Object.keys(allimageData)
+        .filter((key) => key !== "banner")
+        .flatMap((key) => allimageData[key])
+    : [];
 
   const [selectedImage, setSelectedImage] = useState<ImageItems | null>(null);
 
   return (
     <div>
       <div className=" min-[350px]:max-h-[85vh] md:max-h-[90vh] overflow-y-auto ">
-        {filteredImages && filteredImages.length > 0 ? ( //filteredImages라는 값은 GalleryContainer 함수에서 받아옴, 이를 통해 특정 시즌 이미지만 출력되도록함
+        {withOutBannerImgs && withOutBannerImgs.length > 0 ? ( //filteredImages라는 값은 GalleryContainer 함수에서 받아옴, 이를 통해 특정 시즌 이미지만 출력되도록함
           <Masonry
             breakpointCols={breakpointColumnsObj}
             className="my-masonry-grid flex gap-4" // flex 컨테이너 클래스 이미지 열 갭
             columnClassName="my-masonry-grid_column gap-4 bg-clip-padding " // 각 컬럼에 적용될 클래스 (gap-4는 gutter 역할)
           >
-            {filteredImages.map((image: ImageItems) => (
+            {withOutBannerImgs.map((image: ImageItems) => (
               <div
                 key={image.id}
-                className=" rounded shadow-xl mb-4"
+                className=" rounded shadow-xl mb-4 "
                 onClick={() => setSelectedImage(image)}
               >
                 <img
                   src={image.urlConverted}
                   alt={image.title}
-                  className="w-full  object-cover transition hover:-translate-y-1 hover:scale-110"
+                  className="w-full  object-cover transition hover:-translate-y-1 hover:scale-110 hover:shadow-xl/70"
                   fetchPriority="high"
                   loading="lazy"
                 />
@@ -47,17 +56,17 @@ export default function GalleryContents({ filteredImages }: AllImageData) {
           <p className="text-black">No images found for the selected season.</p>
         )}
       </div>
-      {selectedImage && (
+      {selectedImage && !isMobile && (
         <Modal
           isOpen={selectedImage !== null}
           onRequestClose={() => setSelectedImage(null)} // 4. 모달 닫기
-          className="w-auto h-auto max-w-3xl flex flex-col items-center justify-center focus:outline-none gap-8"
+          className="w-auto max-w-2xl flex flex-col items-center justify-center focus:outline-none gap-8"
           overlayClassName=" fixed inset-0 bg-white flex items-center justify-center"
         >
           <img
             src={selectedImage.url} // 5. 선택된 이미지의 원본 URL 사용
             alt={selectedImage.title}
-            className="max-w-full max-h-full object-contain "
+            className="w-full h-full object-contain "
           />
           <button
             className="bg-white text-black ring-3 ring-black rounded-xl p-5 text-7xl w-3xl"


### PR DESCRIPTION
galleryContents 파일에서 이미지 클릭시 모달기능을 통해 이미지가 화면을 꽉 채우는 기능이 있었음 

모바일에서 사용시 무분별하게 모달창이 팝업되어 이미지가 커지는 현상이 발생함. 

모바일 환경에서 모달창이 없어도 충분히 이미지가 크게 보이기에 모바일에서만 모달창을 통한 이미지 확대 기능을 삭제하기로 결정함 

react-responsive 플러그인을 사용하여 max-width를 기반으로 모바일 유무를 판단하고 모바일일 경우 모달창 엘리먼트 자체를 비활성화하는 방식으로 구현